### PR TITLE
Refix Git Push

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -50,6 +50,10 @@ func Clone(c *Client, args []string) {
 	Config(c, []string{"--set", "remote.origin.url", repoid})
 	Config(c, []string{"--set", "branch.master.remote", "origin"})
 
+	// This should be smarter and try and get the HEAD branch from Fetch.
+	// The HEAD refspec isn't necessarily named refs/heads/master.
+	Config(c, []string{"--set", "branch.master.merge", "refs/heads/master"})
+
 	Fetch(c, repo, []string{"origin"})
 	Reset(c, repo, []string{"--hard"})
 }

--- a/fetch.go
+++ b/fetch.go
@@ -5,7 +5,6 @@ import (
 	libgit "github.com/driusan/git"
 	"io/ioutil"
 	"os"
-	"strings"
 )
 
 func Fetch(c *Client, repo *libgit.Repository, args []string) {
@@ -46,8 +45,7 @@ func Fetch(c *Client, repo *libgit.Repository, args []string) {
 	unpack(c, repo, pack)
 	for _, ref := range refs {
 		if c.GitDir != "" {
-			refloc := fmt.Sprintf("%s/%s", c.GitDir, strings.TrimSpace(ref.Refname))
-			refloc = strings.TrimSpace(refloc)
+			refloc := fmt.Sprintf("%s/%s", c.GitDir, ref.Refname.String())
 			fmt.Printf("Creating %s with %s", refloc, ref.Sha1)
 			ioutil.WriteFile(
 				refloc,

--- a/push.go
+++ b/push.go
@@ -40,8 +40,7 @@ func Push(c *Client, repo *libgit.Repository, args []string) {
 		return
 	}
 	for _, ref := range refs {
-		trimmed := strings.TrimSuffix(ref.Refname, "\000")
-		trimmed = strings.TrimSpace(trimmed)
+		trimmed := ref.Refname.String()
 		if trimmed == mergebranch {
 			localSha, err := RevParse(c, repo, []string{args[0]})
 			if err != nil {

--- a/retrieve.go
+++ b/retrieve.go
@@ -254,12 +254,9 @@ func (s *smartHTTPServerRetriever) getRefs(service, expectedmime string) (io.Rea
 	if err != nil {
 		return nil, err
 	}
-	println("I am now here2")
 	if resp.StatusCode >= 400 {
-		println("I am now here2.5")
 		return nil, errors.New(resp.Status)
 	}
-	println("I am now here3")
 	// It worked, so return the Body reader. It's the callers responsibility
 	// to close it.
 	return resp.Body, nil
@@ -311,7 +308,12 @@ func (s smartHTTPServerRetriever) NegotiatePack() ([]*Reference, *os.File, error
 		panic(response)
 	}
 
-	f, _ := ioutil.TempFile("", "gitpack")
+	// Use a tempfile so that the body is a io.ReadSeeker
+	f, err := ioutil.TempFile("", "gitpack")
+	if err != nil {
+		return refs, f, err
+	}
+
 	io.Copy(f, r2.Body)
 
 	return refs, f, nil


### PR DESCRIPTION
Somehow, the bug fix for cloning from github disappeared (probably because go-git push implicitly adds --force.)

This readds 03c339e to master and also fixes a bug where branch.master.merge wasn't being set on go-git clone. This change should fix issue #2.