### PR TITLE
Fixed support for git branch that was lost in refactoring

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	libgit "github.com/driusan/git"
 )
 
 // A file represents a file (or directory) relative to os.Getwd()
@@ -98,19 +96,6 @@ func NewClient(gitDir, workDir string) (*Client, error) {
 	return &Client{GitDir(gitdir), WorkDir(workdir)}, nil
 }
 
-func (c *Client) GetHeadID() (string, error) {
-	// Temporary hack until libgit is removed.
-	repo, err := libgit.OpenRepository(c.GitDir.String())
-	if err != nil {
-		return "", err
-	}
-	if headBranch := c.GetHeadBranch(); headBranch != "" {
-		return repo.GetCommitIdOfBranch(c.GetHeadBranch())
-	}
-	return "", InvalidHead
-
-}
-
 /*
 func (c *Client) GetHeadSha1() (Sha1, error) {
 	panic("Not yet reimplemented")
@@ -120,10 +105,6 @@ func (c *Client) GetHeadSha1() (Sha1, error) {
 		return "", InvalidHead
 }
 */
-
-func (c *Client) GetBranches() ([]string, error) {
-	panic("Not implemented")
-}
 
 func (c *Client) GetHeadBranch() string {
 	file, _ := c.GitDir.Open("HEAD")
@@ -142,19 +123,6 @@ func (c *Client) GetHeadBranch() string {
 	}
 	return ""
 
-}
-
-func (c *Client) HaveObject(idStr string) (found, packed bool, err error) {
-	// As a temporary hack use libgit, because I don't have time to
-	// make sure pack files are looked into properly yet.
-	repo, err := libgit.OpenRepository(c.GitDir.String())
-	if err != nil {
-		return false, false, err
-	}
-	return repo.HaveObject(idStr)
-}
-func (c *Client) CreateBranch(name string, sha1 Sha1) error {
-	panic("Unimplemented")
 }
 
 func (c *Client) ExecEditor(f File) error {

--- a/client_hacks.go
+++ b/client_hacks.go
@@ -1,0 +1,47 @@
+package main
+
+// This file contains temporary hacks that still use libgit, because
+// they haven't been rewritten yet in a way that doesn't depend on it.
+// They should be removed/rewritten.
+import (
+	libgit "github.com/driusan/git"
+)
+
+func (c *Client) GetBranches() ([]string, error) {
+	repo, err := libgit.OpenRepository(c.GitDir.String())
+	if err != nil {
+		return nil, err
+	}
+	return repo.GetBranches()
+}
+
+func (c *Client) CreateBranch(name string, sha1 Sha1) error {
+	repo, err := libgit.OpenRepository(c.GitDir.String())
+	if err != nil {
+		return err
+	}
+	return repo.CreateBranch(name, sha1.String())
+}
+
+func (c *Client) HaveObject(idStr string) (found, packed bool, err error) {
+	// As a temporary hack use libgit, because I don't have time to
+	// make sure pack files are looked into properly yet.
+	repo, err := libgit.OpenRepository(c.GitDir.String())
+	if err != nil {
+		return false, false, err
+	}
+	return repo.HaveObject(idStr)
+}
+
+func (c *Client) GetHeadID() (string, error) {
+	// Temporary hack until libgit is removed.
+	repo, err := libgit.OpenRepository(c.GitDir.String())
+	if err != nil {
+		return "", err
+	}
+	if headBranch := c.GetHeadBranch(); headBranch != "" {
+		return repo.GetCommitIdOfBranch(c.GetHeadBranch())
+	}
+	return "", InvalidHead
+
+}

--- a/main.go
+++ b/main.go
@@ -120,6 +120,8 @@ func main() {
 	}
 	c, err := NewClient(*gitdir, *workdir)
 	cmd := args[0]
+	args = args[1:]
+
 	if err != nil && requiresGitDir(cmd) {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(3)
@@ -129,9 +131,6 @@ func main() {
 		os.Exit(4)
 	}
 
-	if len(args) > 1 {
-		args = args[1:]
-	}
 
 	// TODO: Get rid of this. It's only here for a transition.
 	var repo *libgit.Repository


### PR DESCRIPTION
The minimal support for "git branch" was lost when refactoring to try and get rid of the dependency on github.com/driusan/git and adding the "Client" type. This adds it back by moving the usage of the unwanted library into a new file, so it can be slowly removed without losing any functionality.